### PR TITLE
Add brute-force SAT solver and tests

### DIFF
--- a/src/sat_solver.cpp
+++ b/src/sat_solver.cpp
@@ -1,0 +1,29 @@
+#include "sat_solver.h"
+#include <cstdlib>
+#include <vector>
+
+bool is_satisfiable(int num_vars, const std::vector<std::vector<int>>& cnf) {
+    // Iterate over all possible assignments
+    const std::size_t total = static_cast<std::size_t>(1) << num_vars;
+    for (std::size_t mask = 0; mask < total; ++mask) {
+        bool formula_sat = true;
+        for (const auto& clause : cnf) {
+            bool clause_sat = false;
+            for (int lit : clause) {
+                int var = std::abs(lit) - 1; // convert to 0-index
+                bool value = (mask >> var) & 1;
+                if (lit < 0) value = !value;
+                if (value) {
+                    clause_sat = true;
+                    break;
+                }
+            }
+            if (!clause_sat) {
+                formula_sat = false;
+                break;
+            }
+        }
+        if (formula_sat) return true;
+    }
+    return false;
+}

--- a/src/sat_solver.h
+++ b/src/sat_solver.h
@@ -1,0 +1,11 @@
+#ifndef SAT_SOLVER_H
+#define SAT_SOLVER_H
+#include <vector>
+
+// CNF is represented as a vector of clauses; each clause is a vector of integers.
+// Positive integer i represents variable i (1-indexed), negative integer -i represents NOT variable i.
+// Example clause (x1 OR NOT x2) -> {1, -2}
+
+bool is_satisfiable(int num_vars, const std::vector<std::vector<int>>& cnf);
+
+#endif // SAT_SOLVER_H

--- a/tests/test_sat.cpp
+++ b/tests/test_sat.cpp
@@ -1,0 +1,42 @@
+#include "gtest/gtest.h"
+#include "../src/sat_solver.h"
+#include <chrono>
+
+TEST(SATSolverTest, SingleVariable) {
+    std::vector<std::vector<int>> cnf = {{1}};
+    EXPECT_TRUE(is_satisfiable(1, cnf));
+}
+
+TEST(SATSolverTest, Contradiction) {
+    std::vector<std::vector<int>> cnf = {{1}, {-1}};
+    EXPECT_FALSE(is_satisfiable(1, cnf));
+}
+
+TEST(SATSolverTest, SmallFormula) {
+    std::vector<std::vector<int>> cnf = {{1, 2}, {-1, 3}};
+    EXPECT_TRUE(is_satisfiable(3, cnf));
+}
+
+TEST(SATSolverTest, LargeFormulaRuntime) {
+    const int n = 25;
+    std::vector<std::vector<int>> cnf;
+    for (int i = 1; i <= n; ++i) {
+        cnf.push_back({i});
+    }
+    std::vector<int> neg_clause;
+    for (int i = 1; i <= n; ++i) neg_clause.push_back(-i);
+    cnf.push_back(neg_clause);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    bool sat = is_satisfiable(n, cnf);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = end - start;
+    EXPECT_FALSE(sat);
+    EXPECT_GT(diff.count(), 1.0);
+    std::cerr << "Large formula runtime: " << diff.count() << " seconds\n";
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- implement simple SAT solver that enumerates assignments
- add tests validating solver and measuring runtime on a 25 variable case
- replace manual tests with Google Test framework
- require runtime of large formula to exceed one second

## Testing
- `g++ -std=c++17 tests/test_sat.cpp src/sat_solver.cpp -lgtest -lgtest_main -pthread -o tests/test_sat && ./tests/test_sat`


------
https://chatgpt.com/codex/tasks/task_e_684b59141d74832299461f0e7211c468