### PR TITLE
Add fast SAT solver and runtime test

### DIFF
--- a/src/sat_solver.cpp
+++ b/src/sat_solver.cpp
@@ -27,3 +27,103 @@ bool is_satisfiable(int num_vars, const std::vector<std::vector<int>>& cnf) {
     }
     return false;
 }
+
+namespace {
+
+// Remove satisfied clauses and falsified literals from the CNF when variable
+// `var` is assigned the boolean value `value`.
+std::vector<std::vector<int>> apply_assignment(const std::vector<std::vector<int>>& cnf,
+                                               int var, bool value) {
+    std::vector<std::vector<int>> out;
+    for (const auto& clause : cnf) {
+        bool satisfied = false;
+        std::vector<int> new_clause;
+        for (int lit : clause) {
+            int v = std::abs(lit) - 1;
+            if (v == var) {
+                bool lit_val = value;
+                if (lit < 0) lit_val = !lit_val;
+                if (lit_val) { satisfied = true; break; }
+                // literal evaluates to false, so skip it
+            } else {
+                new_clause.push_back(lit);
+            }
+        }
+        if (!satisfied) {
+            if (new_clause.empty()) {
+                out.push_back({});
+                return out; // contains an empty clause -> unsatisfiable
+            }
+            out.push_back(std::move(new_clause));
+        }
+    }
+    return out;
+}
+
+// Unit propagation. Returns false if a conflict is detected.
+bool propagate_units(std::vector<std::vector<int>>& cnf,
+                     std::vector<int>& assignment) {
+    while (true) {
+        bool changed = false;
+        for (const auto& clause : cnf) {
+            if (clause.size() == 1) {
+                int lit = clause[0];
+                int var = std::abs(lit) - 1;
+                bool val = lit > 0;
+                if (assignment[var] != 0) {
+                    bool cur = assignment[var] > 0;
+                    if (cur != val) return false;
+                } else {
+                    assignment[var] = val ? 1 : -1;
+                    cnf = apply_assignment(cnf, var, val);
+                }
+                changed = true;
+                break; // restart scanning from beginning
+            }
+        }
+        if (!changed) break;
+        for (const auto& cl : cnf) {
+            if (cl.empty()) return false;
+        }
+    }
+    return true;
+}
+
+bool dpll(std::vector<std::vector<int>> cnf,
+          std::vector<int> assignment,
+          int num_vars) {
+    if (!propagate_units(cnf, assignment)) return false;
+    if (cnf.empty()) return true;
+    // choose first unassigned variable
+    int var = -1;
+    for (int i = 0; i < num_vars; ++i) {
+        if (assignment[i] == 0) { var = i; break; }
+    }
+    if (var == -1) return false;
+
+    // try true
+    {
+        auto assn = assignment;
+        assn[var] = 1;
+        auto cnf_true = apply_assignment(cnf, var, true);
+        if (!cnf_true.empty() && dpll(cnf_true, assn, num_vars))
+            return true;
+        if (cnf_true.empty()) return true; // all clauses satisfied
+    }
+
+    // try false
+    assignment[var] = -1;
+    auto cnf_false = apply_assignment(cnf, var, false);
+    if (!cnf_false.empty() && dpll(cnf_false, assignment, num_vars))
+        return true;
+    if (cnf_false.empty()) return true;
+
+    return false;
+}
+
+} // namespace
+
+bool is_satisfiable_fast(int num_vars, const std::vector<std::vector<int>>& cnf) {
+    std::vector<int> assignment(num_vars, 0);
+    return dpll(cnf, assignment, num_vars);
+}

--- a/src/sat_solver.h
+++ b/src/sat_solver.h
@@ -7,5 +7,9 @@
 // Example clause (x1 OR NOT x2) -> {1, -2}
 
 bool is_satisfiable(int num_vars, const std::vector<std::vector<int>>& cnf);
+// A simple DPLL style solver with unit propagation. This is typically much
+// faster than the brute force algorithm above and is used for the runtime
+// comparison in the tests.
+bool is_satisfiable_fast(int num_vars, const std::vector<std::vector<int>>& cnf);
 
 #endif // SAT_SOLVER_H

--- a/tests/test_sat.cpp
+++ b/tests/test_sat.cpp
@@ -36,6 +36,25 @@ TEST(SATSolverTest, LargeFormulaRuntime) {
     std::cerr << "Large formula runtime: " << diff.count() << " seconds\n";
 }
 
+TEST(SATSolverTest, LargeFormulaFastRuntime) {
+    const int n = 25;
+    std::vector<std::vector<int>> cnf;
+    for (int i = 1; i <= n; ++i) {
+        cnf.push_back({i});
+    }
+    std::vector<int> neg_clause;
+    for (int i = 1; i <= n; ++i) neg_clause.push_back(-i);
+    cnf.push_back(neg_clause);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    bool sat = is_satisfiable_fast(n, cnf);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = end - start;
+    EXPECT_FALSE(sat);
+    EXPECT_LT(diff.count(), 1.0);
+    std::cerr << "Large formula fast runtime: " << diff.count() << " seconds\n";
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- implement `is_satisfiable_fast` using a simple DPLL solver
- expose the new API in the header
- add a runtime test ensuring the fast solver is sub-second on a large instance

## Testing
- `g++ -std=c++17 tests/test_sat.cpp src/sat_solver.cpp -lgtest -lgtest_main -pthread -o test_sat && ./test_sat >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_684b5bf2f1b4832289c2df4c9d505600