### PR TITLE
Fix profile URN resolver matching short template placeholder

### DIFF
--- a/linkedin/linkedin_mcp/profile_resolver.py
+++ b/linkedin/linkedin_mcp/profile_resolver.py
@@ -18,8 +18,10 @@ _PROFILE_SLUG_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Matches any urn:li:fsd_profile:IDENTIFIER in text or HTML
-_PROFILE_URN_RE = re.compile(r"urn:li:fsd_profile:([A-Za-z0-9_-]+)")
+# Matches any urn:li:fsd_profile:IDENTIFIER in text or HTML.
+# The {5,} floor skips literal template strings like "urn:li:fsd_profile:urn"
+# that appear in profile page HTML and would otherwise produce a garbage URN.
+_PROFILE_URN_RE = re.compile(r"urn:li:fsd_profile:([A-Za-z0-9_-]{5,})")
 
 
 def extract_slug(profile_url: str) -> str | None:

--- a/linkedin/tests/test_profile_resolver.py
+++ b/linkedin/tests/test_profile_resolver.py
@@ -62,6 +62,21 @@ def test_extract_urn_from_html_picks_first_match() -> None:
     assert extract_urn_from_html(html) == "urn:li:fsd_profile:FIRST"
 
 
+def test_extract_urn_from_html_skips_short_template_placeholder() -> None:
+    """Real profile pages embed template strings like 'urn:li:fsd_profile:urn:li:...'
+    before any real ACoA... identifier. The resolver must skip those and return
+    the real URN instead of 'urn:li:fsd_profile:urn'.
+    """
+    html = (
+        'schema="urn:li:fsd_profile:urn:li:fs_miniProfile:XYZ" '
+        'data={"entityUrn":"urn:li:fsd_profile:ACoAAGdEz4EBa1TobuR0C7U"}'
+    )
+    assert (
+        extract_urn_from_html(html)
+        == "urn:li:fsd_profile:ACoAAGdEz4EBa1TobuR0C7U"
+    )
+
+
 # --- resolve_profile_urn ---
 
 


### PR DESCRIPTION
## Summary
- `_PROFILE_URN_RE` in `linkedin_mcp/profile_resolver.py` accepted identifiers as short as one character. LinkedIn profile-page HTML embeds a literal template string like `urn:li:fsd_profile:urn:li:fs_miniProfile:...` before any real `ACoA…` URN, so the regex captured just `urn` and `resolve_profile_urn` returned `urn:li:fsd_profile:urn` — which the Voyager `saveToPdf` mutation rejects with a 403 `This profile can't be accessed`.
- Tightened the identifier class to `{5,}` so the first match is the real URN. 5 is comfortably below any real LinkedIn identifier (they're ~40 chars starting with `ACoA`) and above the 3-char `urn` placeholder.

## Test plan
- [x] `pytest tests/test_profile_resolver.py` — 15/15 pass, including new `test_extract_urn_from_html_skips_short_template_placeholder`
- [x] Live check: `resolve_profile_urn("https://www.linkedin.com/in/alanrussian", client)` now returns `urn:li:fsd_profile:ACoAAAouva8BdzvnJMQGF-0p4QP3akJDeJpJR6E` instead of the broken `urn:li:fsd_profile:urn`
- [x] Downloaded 43 profile PDFs end-to-end with the patched resolver (prior run hit the bug; rerun with the fix was clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)